### PR TITLE
Add Linux Build Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ windows/x64/
 *.user
 
 *.aps
+
+src/*.o
+linux/*.o
+linux/*.so
+

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ This project will allow you to build your own DLL and customize the source code.
 #### Windows
 [Visual studio](https://visualstudio.microsoft.com/)
 #### Linux
-to-do
+Dependencies:
+```
+libusb-1.0, libusb-dev, hidapi, libhidapi-dev
+```
+Additionally, you will need `pkg-config`, `git`, `make` and `gcc` to compile the Library.
 
 ### Installing
+## Windows
 ```
 git clone --recursive https://github.com/WootingKb/wooting-rgb-sdk.git 
 ```
@@ -28,6 +33,15 @@ Now hit the build and find your DLL in the folder depending on your configuratio
 ```
 \wooting-rgb-sdk\windows\Release\wooting-rgb-sdk.dll
 ```
+
+## Linux
+Clone the Git Repository:
+```
+git clone https://github.com/WootingKb/wooting-rgb-sdk.git
+```
+Change into the Linux Directory using `cd wooting-rgb-sdk/linux` and simply run `make`.
+
+If you wish to use the Library yourself it might be useful to install it to your System. Do so with `sudo make install`
 
 ## Example
 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -1,0 +1,25 @@
+all: libwooting-rgb-sdk.so
+
+CC ?= gcc
+CFLAGS ?= -Wall -g -fPIC
+
+LDFLAGS ?= -Wall -g
+
+OBJS = ../src/wooting-rgb-sdk.o ../src/wooting-usb.o
+LIBS = `pkg-config libusb-1.0 --libs`
+INCLUDES ?= `pkg-config hidapi-libusb --cflags` -I../src `pkg-config libusb-1.0 --cflags`
+
+libwooting-rgb-sdk.so: $(OBJS)
+	$(CC) $(LDFLAGS) $(LIBS) -shared -fPIC -Wl,-soname,$0.0 $^ -o $@
+
+$(OBJS): %.o: %.c
+	$(CC) $(CFLAGS) -c $(INCLUDES) $< -o $@
+
+clean:
+	rm -f $(OBJS)
+
+install: libwooting-rgb-sdk.so
+	cp libwooting-rgb-sdk.so /usr/lib/libwooting-rgb-sdk.so
+	cp libwooting-rgb-sdk.pc /usr/lib/pkgconfig/libwooting-rgb-sdk.pc
+
+.PHONY: clean libs

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -6,7 +6,7 @@ CFLAGS ?= -Wall -g -fPIC
 LDFLAGS ?= -Wall -g
 
 OBJS = ../src/wooting-rgb-sdk.o ../src/wooting-usb.o
-LIBS = `pkg-config libusb-1.0 --libs`
+LIBS = `pkg-config libusb-1.0 --libs` `pkg-config hidapi-libusb --libs`
 INCLUDES ?= `pkg-config hidapi-libusb --cflags` -I../src `pkg-config libusb-1.0 --cflags`
 
 libwooting-rgb-sdk.so: $(OBJS)

--- a/linux/libwooting-rgb-sdk.pc
+++ b/linux/libwooting-rgb-sdk.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: libwooting-rgb-sdk
+Description: Wooting Keyboard RGB SDK
+Version: VERSION
+Requires: hidapi-libusb
+Cflags: -I${includedir}
+Libs: -L${libdir} -llibwooting-rgb-sdk

--- a/src/wooting-rgb-sdk.h
+++ b/src/wooting-rgb-sdk.h
@@ -7,10 +7,15 @@
 */
 #pragma once
 
+#ifdef _WIN32
 #ifdef WOOTINGRGBSDK_EXPORTS  
 #define WOOTINGRGBSDK_API __declspec(dllexport)   
 #else  
 #define WOOTINGRGBSDK_API __declspec(dllimport)   
+#endif
+#else
+// __declspec is win32 only
+#define WOOTINGRGBSDK_API
 #endif
 
 #include "stdint.h"

--- a/src/wooting-usb.c
+++ b/src/wooting-usb.c
@@ -7,6 +7,7 @@
 */
 #include "stdint.h"
 #include "stdbool.h"
+#include "string.h"
 #include "wooting-usb.h"
 #include "hidapi.h"
 


### PR DESCRIPTION
Forgive me if I'm wrong, but from what I see the linux-build Branch was abandoned, just as #4.

This PR rebases the Changes and adds some Enhancements:
- The Makefile now has an `install` target to more easily link to it from different Projects
- The Makefile no longer links to the bundled hidapi submodule, but to the System's Library
- A .pc file was added so that pkg-config can pick up on the Library. This allows usage of the Meson or CMake buildsystems'  dependency tags
- Added Documentation
