### PR TITLE
Ease C++ Support

### DIFF
--- a/src/wooting-rgb-sdk.h
+++ b/src/wooting-rgb-sdk.h
@@ -7,6 +7,10 @@
 */
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef WOOTINGRGBSDK_EXPORTS  
 #define WOOTINGRGBSDK_API __declspec(dllexport)   
 #else  
@@ -149,3 +153,8 @@ Expected size is 6 row * 21 columns * 3 colors per key = 576 bytes.
 This functions return true (1) if the colours are changed (if auto update flag: updated).
 */
 WOOTINGRGBSDK_API bool wooting_rgb_array_set_full(const uint8_t *colors_buffer);
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
Same as WootingKb/wooting-analog-sdk#8

I don't know if this is actually something that should be in this Repo, but I wanted to offer the option.
This allows to import the SDK without requiring the `extern "C"` command in C++ Projects, and therefore make them cleaner. It has no effect on C builds/Projects.