### PR TITLE
linux: Makefile: remove empty line between CPPFLAGS and LDFLAGS

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -5,7 +5,6 @@ prefix ?= /usr/local
 CC ?= gcc
 CFLAGS ?= -Wall -g -fPIC
 CPPFLAGS ?= #-DDEBUG_LOG
-
 LDFLAGS ?= -Wall -g -Wl,--no-as-needed
 
 OBJS = ../src/wooting-rgb-sdk.o ../src/wooting-usb.o


### PR DESCRIPTION
Sorry, this should have gone in the previous `CPPFLAGS` PR, but I messed up and I can't live with that lonely `LDFLAGS` there… Unless `LDFLAGS` was separated on purpose?