### PR TITLE
Use void instead of empty parameter list

### DIFF
--- a/src/wooting-rgb-sdk.h
+++ b/src/wooting-rgb-sdk.h
@@ -177,7 +177,7 @@ This function returns a pointer to a struct which provides various relevant deta
 @returns
 This functions returns a pointer to a `WOOTING_USB_META` struct which contains relevant Device Information
 */
-WOOTINGRGBSDK_API const WOOTING_USB_META* wooting_rgb_device_info();
+WOOTINGRGBSDK_API const WOOTING_USB_META* wooting_rgb_device_info(void);
 
 #ifdef __cplusplus
 }

--- a/src/wooting-usb.h
+++ b/src/wooting-usb.h
@@ -54,7 +54,7 @@ void wooting_usb_disconnect(bool trigger_cb);
 
 bool wooting_usb_find_keyboard(void);
 
-WOOTING_USB_META *wooting_usb_get_meta();
+WOOTING_USB_META *wooting_usb_get_meta(void);
 
 bool wooting_usb_send_buffer(RGB_PARTS part_number, uint8_t rgb_buffer[]);
 bool wooting_usb_send_feature(uint8_t commandId, uint8_t parameter0,


### PR DESCRIPTION
Empty parameter lists accept any amount of parameters, allowing for
incorrect usage of a function.  Passing any parameters to a void
parameter list results in compilation error, making such incorrect usage
impossible.