### PR TITLE
Fix Windows DLL exports and add HID read methods to WootingUSB

### DIFF
--- a/src/wooting-usb.c
+++ b/src/wooting-usb.c
@@ -434,3 +434,29 @@ bool wooting_usb_send_feature(uint8_t commandId, uint8_t parameter0, uint8_t par
 		return false;
 	}
 }
+
+void wooting_usb_read_response_timeout(uint8_t *buff, size_t len, int milliseconds)
+{
+	int result = hid_read_timeout(keyboard_handle, buff, len, milliseconds);
+#ifdef DEBUG_LOGs
+	printf("Read_timeout result \n");
+	for(int i = 0; i < len; i++ )
+	{
+		printf("%d", buff[i]);
+	}
+	printf("\n");
+#endif
+}
+
+void wooting_usb_read_response(uint8_t *buff, size_t len)
+{
+	int result = hid_read(keyboard_handle, buff, len);
+#ifdef DEBUG_LOGs
+	printf("Read_timeout result \n");
+	for(int i = 0; i < len; i++ )
+	{
+		printf("%d", buff[i]);
+	}
+	printf("\n");
+#endif
+}

--- a/src/wooting-usb.c
+++ b/src/wooting-usb.c
@@ -406,7 +406,9 @@ bool wooting_usb_send_feature(uint8_t commandId, uint8_t parameter0, uint8_t par
 		return false;
 	}
 
+	#ifdef DEBUG_LOG
 	printf("Sending feature: %d\n", commandId);
+	#endif
 
 	uint8_t report_buffer[WOOTING_COMMAND_SIZE];
 
@@ -442,7 +444,9 @@ int wooting_usb_send_feature_with_response(uint8_t *buff, size_t len, uint8_t co
 		return -1;
 	}
 
+	#ifdef DEBUG_LOG
 	printf("Sending feature with response: %d\n", commandId);
+	#endif
 
 	uint8_t report_buffer[WOOTING_COMMAND_SIZE];
 

--- a/src/wooting-usb.h
+++ b/src/wooting-usb.h
@@ -25,6 +25,7 @@ extern "C" {
 #ifdef DEBUG_LOG
 #include <stdio.h>
 #endif
+#include <stddef.h>
 
 typedef void (*void_cb)(void);
 
@@ -77,6 +78,7 @@ WOOTINGRGBSDK_API bool wooting_usb_find_keyboard(void);
 
 WOOTINGRGBSDK_API WOOTING_USB_META *wooting_usb_get_meta(void);
 WOOTINGRGBSDK_API bool wooting_usb_use_v2_interface(void);
+WOOTINGRGBSDK_API size_t wooting_usb_get_response_size(void);
 
 WOOTINGRGBSDK_API bool wooting_usb_send_buffer_v1(RGB_PARTS part_number, uint8_t rgb_buffer[]);
 WOOTINGRGBSDK_API bool wooting_usb_send_buffer_v2(uint16_t rgb_buffer[WOOTING_RGB_ROWS][WOOTING_RGB_COLS]);

--- a/src/wooting-usb.h
+++ b/src/wooting-usb.h
@@ -7,6 +7,21 @@
  */
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _WIN32
+#ifdef WOOTINGRGBSDK_EXPORTS  
+#define WOOTINGRGBSDK_API __declspec(dllexport)   
+#else  
+#define WOOTINGRGBSDK_API __declspec(dllimport)   
+#endif
+#else
+// __declspec is win32 only
+#define WOOTINGRGBSDK_API
+#endif
+
 #ifdef DEBUG_LOG
 #include <stdio.h>
 #endif
@@ -55,16 +70,20 @@ typedef struct _KeyboardMatrixID {
 #define WOOTING_RESET_ALL_COMMAND 32
 #define WOOTING_COLOR_INIT_COMMAND 33
 
-void wooting_usb_set_disconnected_cb(void_cb cb);
-void wooting_usb_disconnect(bool trigger_cb);
+WOOTINGRGBSDK_API void wooting_usb_set_disconnected_cb(void_cb cb);
+WOOTINGRGBSDK_API void wooting_usb_disconnect(bool trigger_cb);
 
-bool wooting_usb_find_keyboard(void);
+WOOTINGRGBSDK_API bool wooting_usb_find_keyboard(void);
 
-WOOTING_USB_META *wooting_usb_get_meta(void);
-bool wooting_usb_use_v2_interface(void);
+WOOTINGRGBSDK_API WOOTING_USB_META *wooting_usb_get_meta(void);
+WOOTINGRGBSDK_API bool wooting_usb_use_v2_interface(void);
 
-bool wooting_usb_send_buffer_v1(RGB_PARTS part_number, uint8_t rgb_buffer[]);
-bool wooting_usb_send_buffer_v2(uint16_t rgb_buffer[WOOTING_RGB_ROWS][WOOTING_RGB_COLS]);
-bool wooting_usb_send_feature(uint8_t commandId, uint8_t parameter0,
+WOOTINGRGBSDK_API bool wooting_usb_send_buffer_v1(RGB_PARTS part_number, uint8_t rgb_buffer[]);
+WOOTINGRGBSDK_API bool wooting_usb_send_buffer_v2(uint16_t rgb_buffer[WOOTING_RGB_ROWS][WOOTING_RGB_COLS]);
+WOOTINGRGBSDK_API bool wooting_usb_send_feature(uint8_t commandId, uint8_t parameter0,
                               uint8_t parameter1, uint8_t parameter2,
                               uint8_t parameter3);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/wooting-usb.h
+++ b/src/wooting-usb.h
@@ -83,9 +83,12 @@ WOOTINGRGBSDK_API bool wooting_usb_send_buffer_v2(uint16_t rgb_buffer[WOOTING_RG
 WOOTINGRGBSDK_API bool wooting_usb_send_feature(uint8_t commandId, uint8_t parameter0,
                               uint8_t parameter1, uint8_t parameter2,
                               uint8_t parameter3);
+WOOTINGRGBSDK_API int wooting_usb_send_feature_with_response(uint8_t *buff, size_t len, uint8_t commandId,
+                              uint8_t parameter0, uint8_t parameter1,
+                              uint8_t parameter2, uint8_t parameter3);
 
-WOOTINGRGBSDK_API void wooting_usb_read_response_timeout(uint8_t *buff, size_t len, int milliseconds);
-WOOTINGRGBSDK_API void wooting_usb_read_response(uint8_t *buff, size_t len);
+WOOTINGRGBSDK_API int wooting_usb_read_response_timeout(uint8_t *buff, size_t len, int milliseconds);
+WOOTINGRGBSDK_API int wooting_usb_read_response(uint8_t *buff, size_t len);
 
 #ifdef __cplusplus
 }

--- a/src/wooting-usb.h
+++ b/src/wooting-usb.h
@@ -84,6 +84,9 @@ WOOTINGRGBSDK_API bool wooting_usb_send_feature(uint8_t commandId, uint8_t param
                               uint8_t parameter1, uint8_t parameter2,
                               uint8_t parameter3);
 
+WOOTINGRGBSDK_API void wooting_usb_read_response_timeout(uint8_t *buff, size_t len, int milliseconds);
+WOOTINGRGBSDK_API void wooting_usb_read_response(uint8_t *buff, size_t len);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR fixes the missing exports in the Wooting USB header.
It also adds 3 new functions for reading the HID result.
2 of these functions are just reading the result separately with and without timeout.
The third function is a send feature function with included response written into a pointer handed to the function.

I have also improved the debug logs a tiny bit to reflect what features are send in logs.