### PR TITLE
Updated keyboard name style for consistency

### DIFF
--- a/src/wooting-usb.c
+++ b/src/wooting-usb.c
@@ -68,7 +68,7 @@ static void reset_meta() {
 
 
 static void set_meta_wooting_one() {
-	wooting_usb_meta.model = "Wooting one";
+	wooting_usb_meta.model = "Wooting One";
 	wooting_usb_meta.device_type = DEVICE_KEYBOARD_TKL;
 	wooting_usb_meta.max_rows = WOOTING_RGB_ROWS;
 	wooting_usb_meta.max_columns = WOOTING_ONE_RGB_COLS;
@@ -77,7 +77,7 @@ static void set_meta_wooting_one() {
 }
 
 static void set_meta_wooting_two() {
-	wooting_usb_meta.model = "Wooting two";
+	wooting_usb_meta.model = "Wooting Two";
 	wooting_usb_meta.device_type = DEVICE_KEYBOARD;
 	wooting_usb_meta.max_rows = WOOTING_RGB_ROWS;
 	wooting_usb_meta.max_columns = WOOTING_TWO_RGB_COLS;


### PR DESCRIPTION
Since the other two keyboards have names with the first letter uppercase, i updated these for consistency.

This change also happens to make my life easier when updating the RGB.NET device provider:
Currently the keyboard names are hardcoded as "Wooting One" and "Wooting Two", depending on `wooting_usb_meta.device_type`. I've changed it so the model from the sdk is used instead to more easily support the lekker and HE boards. 

This lets Artemis users keep their profiles intact as changing the name of the keyboard would alter its id.